### PR TITLE
Add support for Jenkins badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ GitHubReadmeGenerator::RakeTask.new :readme do |config|
       :user    => 'raphink', # Dynamic from git
       :project => 'puppet-freeradius', # Dynamic from git?
     },
+    :jenkins => {
+      :badge        => :jenkins,
+      :jenkins_url  => 'https://myjenkinsinstance.com/job/puppet-freeradius'
+    },
   }
 end
 ```
+
+## Dependencies
+
+It's required to install the 'Embeddable Build Status'-plugin in Jenkins if you want to embed Jenkins' build badges.

--- a/github_readme_generator.gemspec
+++ b/github_readme_generator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name               = "github_readme_generator"
-  spec.version            = '0.1.0'
+  spec.version            = '0.1.1'
 
   spec.required_ruby_version     = ">= 1.9.3"
   spec.authors = ["Raphaël Pinson"]

--- a/lib/github_readme_generator/task.rb
+++ b/lib/github_readme_generator/task.rb
@@ -56,6 +56,11 @@ module GitHubReadmeGenerator
             img = "https://img.shields.io/travis/#{v[:user]}/#{v[:project]}.svg"
             link = "https://travis-ci.org/#{v[:user]}/#{v[:project]}"
             out << "[![#{title}](#{img})](#{link})\n"
+          when :jenkins
+            title = v[:title] || 'Build Status'
+            img = "#{v[:jenkins_url]}/badge/icon"
+            link = "#{v[:jenkins_url]}"
+            out << "[![#{title}](#{img})](#{link})\n"
           else
             fail "Unknown badge type '#{v[:badge]}'"
           end


### PR DESCRIPTION
Hey,

I added support for Jenkins build badges in combination with the 'Embeddable Build Status'-plugin. This is currently working fine on our Jenkins. 
